### PR TITLE
Add holder_category field to Plaid.Accounts.Account

### DIFF
--- a/lib/plaid/accounts.ex
+++ b/lib/plaid/accounts.ex
@@ -32,7 +32,8 @@ defmodule Plaid.Accounts do
               official_name: nil,
               type: nil,
               subtype: nil,
-              verification_status: nil
+              verification_status: nil,
+              holder_category: nil
 
     @type t :: %__MODULE__{
             account_id: String.t(),
@@ -43,7 +44,8 @@ defmodule Plaid.Accounts do
             official_name: String.t(),
             type: String.t(),
             subtype: String.t(),
-            verification_status: String.t()
+            verification_status: String.t(),
+            holder_category: String.t()
           }
 
     defmodule Balance do

--- a/lib/plaid/accounts.ex
+++ b/lib/plaid/accounts.ex
@@ -45,7 +45,7 @@ defmodule Plaid.Accounts do
             type: String.t(),
             subtype: String.t(),
             verification_status: String.t(),
-            holder_category: String.t()
+            holder_category: String.t() | nil
           }
 
     defmodule Balance do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -18,7 +18,8 @@ defmodule Plaid.Factory do
           "official_name" => "Plaid Gold Checking",
           "subtype" => "checking",
           "type" => "depository",
-          "verification_status" => nil
+          "verification_status" => nil,
+          "holder_category" => "individual"
         },
         %{
           "account_id" => "6Myq63K1KDSe3lBwp7K1fnEbNGLV4nSxalVdW",
@@ -34,7 +35,8 @@ defmodule Plaid.Factory do
           "official_name" => "Plaid Diamond Credit Card",
           "subtype" => "credit card",
           "type" => "credit",
-          "verification_status" => nil
+          "verification_status" => nil,
+          "holder_category" => "individual"
         },
         %{
           "account_id" => "dhfDuX0N3Yia57IMOGE3m7faUlwvPQLbxs7Oc",
@@ -50,7 +52,8 @@ defmodule Plaid.Factory do
           "official_name" => "Plaid Platinum Checking",
           "subtype" => "checking",
           "type" => "depository",
-          "verification_status" => "automatically_verified"
+          "verification_status" => "automatically_verified",
+          "holder_category" => "business"
         }
       ],
       "item" => %{
@@ -413,7 +416,8 @@ defmodule Plaid.Factory do
           "name" => "Plaid Checking",
           "official_name" => "Plaid Gold Checking",
           "subtype" => "checking",
-          "type" => "depository"
+          "type" => "depository",
+          "holder_category" => "individual"
         },
         %{
           "account_id" => "6Myq63K1KDSe3lBwp7K1fnEbNGLV4nSxalVdW",
@@ -428,7 +432,8 @@ defmodule Plaid.Factory do
           "name" => "Plaid Credit Card",
           "official_name" => "Plaid Diamond Credit Card",
           "subtype" => "credit card",
-          "type" => "credit"
+          "type" => "credit",
+          "holder_category" => "individual"
         }
       ],
       "transactions" => [
@@ -667,7 +672,8 @@ defmodule Plaid.Factory do
           "name" => "Plaid Checking",
           "official_name" => "Plaid Gold Standard 0% Interest Checking",
           "subtype" => "checking",
-          "type" => "depository"
+          "type" => "depository",
+          "holder_category" => "individual"
         },
         %{
           "account_id" => "dLb3JWRbARtppGe9PEMlIKwdP5lEE7tZNgeXy",
@@ -682,7 +688,8 @@ defmodule Plaid.Factory do
           "name" => "Plaid IRA",
           "official_name" => nil,
           "subtype" => "ira",
-          "type" => "investment"
+          "type" => "investment",
+          "holder_category" => "retirement"
         }
       ],
       "investment_transactions" => [
@@ -800,7 +807,8 @@ defmodule Plaid.Factory do
           "name" => "Plaid Checking",
           "official_name" => "Plaid Gold Standard 0% Interest Checking",
           "subtype" => "checking",
-          "type" => "depository"
+          "type" => "depository",
+          "holder_category" => "individual"
         },
         %{
           "account_id" => "dLb3JWRbARtppGe9PEMlIKwdP5lEE7tZNgeXy",
@@ -815,7 +823,8 @@ defmodule Plaid.Factory do
           "name" => "Plaid IRA",
           "official_name" => nil,
           "subtype" => "ira",
-          "type" => "investment"
+          "type" => "investment",
+          "holder_category" => "retirement"
         },
         %{
           "account_id" => "aZDr3gRDLRcaaQ4gDlkdsLJKWjAZZgC74dLXJ",
@@ -830,7 +839,8 @@ defmodule Plaid.Factory do
           "name" => "Plaid 401k",
           "official_name" => nil,
           "subtype" => "401k",
-          "type" => "investment"
+          "type" => "investment",
+          "holder_category" => "retirement"
         }
       ],
       "holdings" => [
@@ -1125,7 +1135,8 @@ defmodule Plaid.Factory do
             }
           ],
           "subtype" => "checking",
-          "type" => "depository"
+          "type" => "depository",
+          "holder_category" => "individual"
         },
         %{
           "account_id" => "3gE5gnRzNyfXpBK5wEEKcymJ5albGVUqg77gr",
@@ -1203,7 +1214,8 @@ defmodule Plaid.Factory do
             }
           ],
           "subtype" => "savings",
-          "type" => "depository"
+          "type" => "depository",
+          "holder_category" => "individual"
         }
       ],
       "item" => %{
@@ -1511,7 +1523,8 @@ defmodule Plaid.Factory do
                 "ownership_type" => nil,
                 "subtype" => "savings",
                 "transactions" => [],
-                "type" => "depository"
+                "type" => "depository",
+                "holder_category" => "individual"
               },
               %{
                 "account_id" => "BxBXxLj1m4HMXBm9WZJyUg9XLd4rKEhw8Pb1J",
@@ -1594,7 +1607,8 @@ defmodule Plaid.Factory do
                 "ownership_type" => nil,
                 "subtype" => "mortgage",
                 "transactions" => [],
-                "type" => "loan"
+                "type" => "loan",
+                "holder_category" => "individual"
               },
               %{
                 "account_id" => "dVzbVMLjrxTnLjX4G66XUp5GLklm4oiZy88yK",
@@ -1696,7 +1710,8 @@ defmodule Plaid.Factory do
                 "ownership_type" => nil,
                 "subtype" => "credit card",
                 "transactions" => [],
-                "type" => "credit"
+                "type" => "credit",
+                "holder_category" => "individual"
               }
             ],
             "date_last_updated" => "2020-06-05T22:47:52Z",


### PR DESCRIPTION
## Description

- Add field `holder_category` to `Plaid.Accounts.Account`.
  - Relevant Plaid documentation: https://plaid.com/docs/api/products/auth/#auth-get-response-accounts-holder-category
  - Note that `holder_category` correctly belongs to Account
- Updated tests.

Ticket: https://linear.app/river-financial/issue/BROK-10660/start-ingesting-holder-category-field-from-plaid

## Checklist

- [x] I **self-reviewed** the code
- [ ] I updated relevant **documentation**
- [x] **Automated tests** demonstrate correctness
- [x] I **manually tested** it
- [ ] I reviewed all direct and transitive dependency changes using [diff.hex.pm](https://diff.hex.pm) and/or [npmdiff.dev](https://npmdiff.dev)

## Security Implications

None.

<!-- Describe any changes that may have implications around authentication, account settings, MFA, API endpoints, user input handling, or anything else that should require a closer look from a security perspective. If there is, add the "security review needed" label to this PR. -->

## How to Test

- Pull changes, build and run tests `mix test`

<!-- (Uncomment if there are relevant links.)
## Links

- [Product Spec](URL HERE)
- [Tech Spec](URL HERE)
- [Figma Design](URL HERE)
-->